### PR TITLE
Add BepInIncompatibility for Magnificus Mod and P03 in Kaycee's Mod

### DIFF
--- a/GrimoraPlugin.cs
+++ b/GrimoraPlugin.cs
@@ -29,6 +29,8 @@ namespace GrimoraMod;
 [BepInDependency(InscryptionAPIPlugin.ModGUID)]
 [BepInDependency("community.inscryption.patch")]
 [BepInDependency("zorro.inscryption.infiniscryption.achievements")]
+[BepInIncompatibility("silenceman.inscryption.magnificusmod")]
+[BepInIncompatibility("zorro.inscryption.infiniscryption.p03kayceerun")]
 [BepInPlugin(GUID, Name, Version)]
 public partial class GrimoraPlugin : BaseUnityPlugin
 {


### PR DESCRIPTION
Unfortunately, people don't read the readme and come to the Inscryption modding discord asking why the game breaks when they have Grimora mod installed with the other act mods D:
This simple change would give a much more predictable and guiding error to those people (and also make debugging their issues easier.)